### PR TITLE
Ajout Liens relatifs

### DIFF
--- a/JVCForumRollback.meta.js
+++ b/JVCForumRollback.meta.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         JVCForumRollback
 // @namespace    https://github.com/Roadou
-// @version      2.8.0
+// @version      2.8.5
 // @description  Ancienne page des forums JVC
 // @author       IceFairy, Atlantis
 // @match        *://www.jeuxvideo.com/forums.htm

--- a/JVCForumRollback.user.js
+++ b/JVCForumRollback.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         JVCForumRollback
 // @namespace    https://github.com/Roadou
-// @version      2.8.0
+// @version      2.8.5
 // @description  Ancienne page des forums JVC
 // @author       IceFairy, Atlantis
 // @match        *://www.jeuxvideo.com/forums.htm
@@ -363,9 +363,7 @@ var oldHtmlCode =
 </div>
 <div class="layout__row layout__row--gutter layout__breadcrumb">
   <div class="px-3 px-lg-0 mt-3 spreadContainer spreadContainer--rowLayout">
-    <nav class=breadcrumb role=navigation><a href=https://www.jeuxvideo.com/ class=breadcrumb__item>jeuxvideo.com</a>
-      <h1 class=breadcrumb__item>Les Forums de jeuxvideo.com : retrouvez notre communauté et venez échanger avec elle sur divers sujets et de nombreux topics</h1>
-    </nav>
+    <nav class=breadcrumb role=navigation><a href=/ class=breadcrumb__item>jeuxvideo.com</a><h1 class=breadcrumb__item>Les Forums de jeuxvideo.com : retrouvez notre communauté et venez échanger avec elle sur divers sujets et de nombreux topics</h1></nav>
   </div>
 </div>
 <div class="layout__row layout__row--gutter layout__content"><input id=ajax_timestamp_preference_user type=hidden name=ajax_timestamp_preference_user value=1714618746> <input id=ajax_hash_preference_user type=hidden name=ajax_hash_preference_user value=f8e4685e486deab35e18d5a8defb8cd897581c94>
@@ -373,7 +371,7 @@ var oldHtmlCode =
     <div class=col-main id=forum-main-col>
       <div class="px-3 px-lg-0">
         <div class=forum-search>
-          <form action=https://www.jeuxvideo.com/forums/recherche.php class=search><button><i class=icon-search></i></button> <input name=q placeholder="Rechercher un forum"></form>
+          <form action=/forums/recherche.php class=search><button><i class=icon-search></i></button> <input name=q placeholder="Rechercher un forum"></form>
         </div>
         <div class=titre-head-bloc>
           <h2 class=titre-bloc>jeuxvideo.com</h2>
@@ -381,7 +379,7 @@ var oldHtmlCode =
         <div class=row>
           <div class=col-lg-6>
             <div class=forum-section>
-              <div class=f-alaune><a href=https://www.jeuxvideo.com/forums/0-3010011-0-1-0-1-0-grand-theft-auto-6.htm><img src=https://image.noelshack.com/fichiers/2023/50/5/1702651559-gta6-jv.jpg>
+              <div class=f-alaune><a href=/forums/0-3010011-0-1-0-1-0-grand-theft-auto-6.htm><img src=https://image.noelshack.com/fichiers/2023/50/5/1702651559-gta6-jv.jpg>
                   <p class=nom-forum>Grand Theft Auto VI</p>
                 </a></div>
             </div>
@@ -390,11 +388,11 @@ var oldHtmlCode =
             <div class=forum-section>
               <div class="fs-header commu"></div>
               <div class=fs-body>
-                <h3><a href=https://www.jeuxvideo.com/forums/0-1000021-0-1-0-1-0-communaute.htm>Communauté</a></h3>
+                <h3><a href=/forums/0-1000021-0-1-0-1-0-communaute.htm>Communauté</a></h3>
                 <ul>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-13-0-1-0-1-0-suggestions-jeuxvideo-com.htm>Suggestions jeuxvideo.com</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-1000047-0-1-0-1-0-boutique-jeuxvideo-com.htm>Boutique jeuxvideo.com</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-76-0-1-0-1-0-sondages.htm>Sondages</a>
+                  <li><a href=/forums/0-13-0-1-0-1-0-suggestions-jeuxvideo-com.htm>Suggestions jeuxvideo.com</a>
+                  <li><a href=/forums/0-1000047-0-1-0-1-0-boutique-jeuxvideo-com.htm>Boutique jeuxvideo.com</a>
+                  <li><a href=/forums/0-76-0-1-0-1-0-sondages.htm>Sondages</a>
                 </ul>
               </div>
             </div>
@@ -405,7 +403,7 @@ var oldHtmlCode =
             <div class=forum-section>
               <div class="fs-header genesis-pass"></div>
               <div class=fs-body>
-                <h3><a href=https://www.jeuxvideo.com/news/1775158/genesis-pass-les-premieres-fonctionnalites-des-nft-jv-sont-la.htm class=xXx>Genesis pass holder</a></h3>
+                <h3><a href=/news/1775158/genesis-pass-les-premieres-fonctionnalites-des-nft-jv-sont-la.htm class=xXx>Genesis pass holder</a></h3>
               </div>
             </div>
           </div>
@@ -415,7 +413,7 @@ var oldHtmlCode =
             <div class=forum-section>
               <div class="fs-header sav"></div>
               <div class=fs-body>
-                <h3><a href=https://www.jeuxvideo.com/forums/0-1000017-0-1-0-1-0-aide-aux-utilisateurs.htm>Aide aux utilisateurs</a></h3>
+                <h3><a href=/forums/0-1000017-0-1-0-1-0-aide-aux-utilisateurs.htm>Aide aux utilisateurs</a></h3>
               </div>
             </div>
           </div>
@@ -423,7 +421,7 @@ var oldHtmlCode =
             <div class=forum-section>
               <div class="fs-header contrib"></div>
               <div class=fs-body>
-                <h3><a href=https://www.jeuxvideo.com/forums/0-1000002-0-1-0-1-0-contribuer-a-jeuxvideo-com.htm>Contributions utilisateurs</a></h3>
+                <h3><a href=/forums/0-1000002-0-1-0-1-0-contribuer-a-jeuxvideo-com.htm>Contributions utilisateurs</a></h3>
               </div>
             </div>
           </div>
@@ -437,55 +435,55 @@ var oldHtmlCode =
             <div class=forum-section>
               <div class="fs-header general-jv"></div>
               <div class=fs-body>
-                <h3><a href=https://www.jeuxvideo.com/forums/0-7-0-1-0-1-0-general-jeux-video.htm>Général Jeu Vidéo</a></h3>
+                <h3><a href=/forums/0-7-0-1-0-1-0-general-jeux-video.htm>Général Jeu Vidéo</a></h3>
                 <ul>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-92-0-1-0-1-0-fps-tps.htm>FPS & TPS</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-93-0-1-0-1-0-rpg-role-playing-game.htm>RPG</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-91-0-1-0-1-0-str-strategie-temps-reel.htm>STR</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-1000028-0-1-0-1-0-jeux-de-combat.htm>Jeux de combat</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-95-0-1-0-1-0-jeux-de-courses.htm>Jeux de courses</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-94-0-1-0-1-0-jeux-d-aventure.htm>Jeux d'aventure</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-96-0-1-0-1-0-jeux-de-sports.htm>Jeux de sports</a>
+                  <li><a href=/forums/0-92-0-1-0-1-0-fps-tps.htm>FPS & TPS</a>
+                  <li><a href=/forums/0-93-0-1-0-1-0-rpg-role-playing-game.htm>RPG</a>
+                  <li><a href=/forums/0-91-0-1-0-1-0-str-strategie-temps-reel.htm>STR</a>
+                  <li><a href=/forums/0-1000028-0-1-0-1-0-jeux-de-combat.htm>Jeux de combat</a>
+                  <li><a href=/forums/0-95-0-1-0-1-0-jeux-de-courses.htm>Jeux de courses</a>
+                  <li><a href=/forums/0-94-0-1-0-1-0-jeux-d-aventure.htm>Jeux d'aventure</a>
+                  <li><a href=/forums/0-96-0-1-0-1-0-jeux-de-sports.htm>Jeux de sports</a>
                 </ul>
                 <ul>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-1000013-0-1-0-1-0-simulation.htm>Simulation</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-1000007-0-1-0-1-0-musiques-de-jeux-video.htm>Musiques de jeux vidéo</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-77-0-1-0-1-0-magazines-de-jeux-video.htm>Magazine de jeux vidéo</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-75-0-1-0-1-0-import.htm>Import</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-72-0-1-0-1-0-heros-de-jeux-video.htm>Héros de jeux vidéo</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-49-0-1-0-1-0-business-du-jeu-video.htm>Business du jeu vidéo</a>
+                  <li><a href=/forums/0-1000013-0-1-0-1-0-simulation.htm>Simulation</a>
+                  <li><a href=/forums/0-1000007-0-1-0-1-0-musiques-de-jeux-video.htm>Musiques de jeux vidéo</a>
+                  <li><a href=/forums/0-77-0-1-0-1-0-magazines-de-jeux-video.htm>Magazine de jeux vidéo</a>
+                  <li><a href=/forums/0-75-0-1-0-1-0-import.htm>Import</a>
+                  <li><a href=/forums/0-72-0-1-0-1-0-heros-de-jeux-video.htm>Héros de jeux vidéo</a>
+                  <li><a href=/forums/0-49-0-1-0-1-0-business-du-jeu-video.htm>Business du jeu vidéo</a>
                 </ul>
               </div>
             </div>
             <div class=forum-section>
               <div class="fs-header oldies"></div>
               <div class=fs-body>
-                <h3><a href=https://www.jeuxvideo.com/forums/0-1000010-0-1-0-1-0-retrogaming.htm>Oldies & Rétrogaming</a></h3>
+                <h3><a href=/forums/0-1000010-0-1-0-1-0-retrogaming.htm>Oldies & Rétrogaming</a></h3>
                 <ul>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-60-0-1-0-1-0-playstation-3.htm>PlayStation 3</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-1000006-0-1-0-1-0-playstation-vita.htm>PlayStation Vita</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-56-0-1-0-1-0-nintendo-ds.htm>Nintendo DS</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-18-0-1-0-1-0-playstation-2.htm>PlayStation 2</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-10-0-1-0-1-0-xbox.htm>Xbox</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-5-0-1-0-1-0-gamecube.htm>Gamecube</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-14-0-1-0-1-0-gameboy-advance.htm>Gameboy Advance</a>
+                  <li><a href=/forums/0-60-0-1-0-1-0-playstation-3.htm>PlayStation 3</a>
+                  <li><a href=/forums/0-1000006-0-1-0-1-0-playstation-vita.htm>PlayStation Vita</a>
+                  <li><a href=/forums/0-56-0-1-0-1-0-nintendo-ds.htm>Nintendo DS</a>
+                  <li><a href=/forums/0-18-0-1-0-1-0-playstation-2.htm>PlayStation 2</a>
+                  <li><a href=/forums/0-10-0-1-0-1-0-xbox.htm>Xbox</a>
+                  <li><a href=/forums/0-5-0-1-0-1-0-gamecube.htm>Gamecube</a>
+                  <li><a href=/forums/0-14-0-1-0-1-0-gameboy-advance.htm>Gameboy Advance</a>
                 </ul>
                 <ul>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-8-0-1-0-1-0-playstation.htm>PlayStation 1</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-12-0-1-0-1-0-dreamcast.htm>Dreamcast</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-42-0-1-0-1-0-playstation-portable.htm>Playstation Portable</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-9-0-1-0-1-0-nintendo-64.htm>Nintendo 64</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-1000025-0-1-0-1-0-megadrive.htm>Megadrive</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-1000026-0-1-0-1-0-super-nintendo.htm>Super Nintendo</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-1000027-0-1-0-1-0-saturn.htm>Saturn</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-19-0-1-0-1-0-gameboy.htm>Gameboy</a>
+                  <li><a href=/forums/0-8-0-1-0-1-0-playstation.htm>PlayStation 1</a>
+                  <li><a href=/forums/0-12-0-1-0-1-0-dreamcast.htm>Dreamcast</a>
+                  <li><a href=/forums/0-42-0-1-0-1-0-playstation-portable.htm>Playstation Portable</a>
+                  <li><a href=/forums/0-9-0-1-0-1-0-nintendo-64.htm>Nintendo 64</a>
+                  <li><a href=/forums/0-1000025-0-1-0-1-0-megadrive.htm>Megadrive</a>
+                  <li><a href=/forums/0-1000026-0-1-0-1-0-super-nintendo.htm>Super Nintendo</a>
+                  <li><a href=/forums/0-1000027-0-1-0-1-0-saturn.htm>Saturn</a>
+                  <li><a href=/forums/0-19-0-1-0-1-0-gameboy.htm>Gameboy</a>
                 </ul>
               </div>
             </div>
             <div class=forum-section>
               <div class="fs-header guerre"></div>
               <div class=fs-body>
-                <h3><a href=https://www.jeuxvideo.com/forums/0-36-0-1-0-1-0-guerre-des-consoles.htm>Guerre des consoles</a></h3>
+                <h3><a href=/forums/0-36-0-1-0-1-0-guerre-des-consoles.htm>Guerre des consoles</a></h3>
               </div>
             </div>
           </div>
@@ -493,49 +491,49 @@ var oldHtmlCode =
             <div class=forum-section>
               <div class="fs-header salons"></div>
               <div class=fs-body>
-                <h3><a href=https://www.jeuxvideo.com/forums/0-1000049-0-1-0-1-0-salons-et-evenements.htm>Salons & événements</a></h3>
+                <h3><a href=/forums/0-1000049-0-1-0-1-0-salons-et-evenements.htm>Salons & événements</a></h3>
                 <ul>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-1000051-0-1-0-1-0-e3.htm>E3</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-1000053-0-1-0-1-0-gamescom.htm>Gamescom</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-1000052-0-1-0-1-0-tokyo-game-show.htm>Tokyo Game Show</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-1000050-0-1-0-1-0-paris-games-week.htm>Paris Games Week</a>
+                  <li><a href=/forums/0-1000051-0-1-0-1-0-e3.htm>E3</a>
+                  <li><a href=/forums/0-1000053-0-1-0-1-0-gamescom.htm>Gamescom</a>
+                  <li><a href=/forums/0-1000052-0-1-0-1-0-tokyo-game-show.htm>Tokyo Game Show</a>
+                  <li><a href=/forums/0-1000050-0-1-0-1-0-paris-games-week.htm>Paris Games Week</a>
                 </ul>
               </div>
             </div>
             <div class=forum-section>
               <div class="fs-header jeu-inde"></div>
               <div class=fs-body>
-                <h3><a href=https://www.jeuxvideo.com/forums/0-3000472-0-1-0-1-0-jeux-independants.htm>Jeux Indépendants</a></h3>
+                <h3><a href=/forums/0-3000472-0-1-0-1-0-jeux-independants.htm>Jeux Indépendants</a></h3>
               </div>
             </div>
             <div class=forum-section>
               <div class="fs-header f2p"></div>
               <div class=fs-body>
-                <h3><a href=https://www.jeuxvideo.com/forums/0-97-0-1-0-1-0-free-to-play.htm>Free to play</a></h3>
+                <h3><a href=/forums/0-97-0-1-0-1-0-free-to-play.htm>Free to play</a></h3>
               </div>
             </div>
             <div class=forum-section>
               <div class="fs-header online"></div>
               <div class=fs-body>
-                <h3><a href=https://www.jeuxvideo.com/forums/0-4-0-1-0-1-0-jeu-en-ligne.htm>Jeux en ligne</a></h3>
+                <h3><a href=/forums/0-4-0-1-0-1-0-jeu-en-ligne.htm>Jeux en ligne</a></h3>
                 <ul>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-84-0-1-0-1-0-e-sport.htm>E-sport</a>
+                  <li><a href=/forums/0-84-0-1-0-1-0-e-sport.htm>E-sport</a>
                 </ul>
               </div>
             </div>
             <div class=forum-section>
               <div class="fs-header annonces"></div>
               <div class=fs-body>
-                <h3><a href=https://www.jeuxvideo.com/forums/0-3-0-1-0-1-0-petites-annonces.htm>Petites annonces</a></h3>
+                <h3><a href=/forums/0-3-0-1-0-1-0-petites-annonces.htm>Petites annonces</a></h3>
                 <ul>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-64-0-1-0-1-0-collectionneurs.htm>Collectionneurs</a>
+                  <li><a href=/forums/0-64-0-1-0-1-0-collectionneurs.htm>Collectionneurs</a>
                 </ul>
               </div>
             </div>
             <div class=forum-section>
               <div class="fs-header handi"></div>
               <div class=fs-body>
-                <h3><a href=https://www.jeuxvideo.com/forums/0-74-0-1-0-1-0-jeux-video-et-handicap.htm>Jeu vidéo & handicap</a></h3>
+                <h3><a href=/forums/0-74-0-1-0-1-0-jeux-video-et-handicap.htm>Jeu vidéo & handicap</a></h3>
               </div>
             </div>
           </div>
@@ -548,34 +546,34 @@ var oldHtmlCode =
             <div class=forum-section>
               <div class="fs-header pc"></div>
               <div class=fs-body>
-                <h3><a href=https://www.jeuxvideo.com/forums/0-3000397-0-1-0-1-0-jeux-pc.htm>Jeux PC</a></h3>
+                <h3><a href=/forums/0-3000397-0-1-0-1-0-jeux-pc.htm>Jeux PC</a></h3>
                 <ul>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-1000040-0-1-0-1-0-plateforme-de-telechargement-pc.htm>Plateforme de Téléchargement PC</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-1000046-0-1-0-1-0-oculus-rift.htm>Réalité Virtuelle</a>
+                  <li><a href=/forums/0-1000040-0-1-0-1-0-plateforme-de-telechargement-pc.htm>Plateforme de Téléchargement PC</a>
+                  <li><a href=/forums/0-1000046-0-1-0-1-0-oculus-rift.htm>Réalité Virtuelle</a>
                 </ul>
               </div>
             </div>
             <div class=forum-section>
               <div class="fs-header sony"></div>
               <div class=fs-body>
-                <h3><a href=https://www.jeuxvideo.com/forums/0-3017788-0-1-0-1-0-playstation-5.htm>PlayStation 5</a></h3>
-                <h3><a href=https://www.jeuxvideo.com/forums/0-1000043-0-1-0-1-0-playstation-4.htm>PlayStation 4</a></h3>
+                <h3><a href=/forums/0-3017788-0-1-0-1-0-playstation-5.htm>PlayStation 5</a></h3>
+                <h3><a href=/forums/0-1000043-0-1-0-1-0-playstation-4.htm>PlayStation 4</a></h3>
                 <ul>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-3000032-0-1-0-1-0-playstation-vr.htm>Playstation VR</a>
+                  <li><a href=/forums/0-3000032-0-1-0-1-0-playstation-vr.htm>Playstation VR</a>
                 </ul>
-                <h3><a href=https://www.jeuxvideo.com/forums/0-1000015-0-1-0-1-0-playstation-store.htm>PlayStation Store</a></h3>
+                <h3><a href=/forums/0-1000015-0-1-0-1-0-playstation-store.htm>PlayStation Store</a></h3>
               </div>
             </div>
             <div class=forum-section>
               <div class="fs-header smartphone"></div>
               <div class=fs-body>
-                <h3><a href=https://www.jeuxvideo.com/forums/0-17-0-1-0-1-0-smartphone-tablettes.htm>Smartphones & tablettes</a></h3>
+                <h3><a href=/forums/0-17-0-1-0-1-0-smartphone-tablettes.htm>Smartphones & tablettes</a></h3>
                 <ul>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-1000029-0-1-0-1-0-iphone-ipod-ipad-watch.htm>iPhone / iPod / iPad / Watch</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-1000041-0-1-0-1-0-windows-phone.htm>Windows Phone</a>
+                  <li><a href=/forums/0-1000029-0-1-0-1-0-iphone-ipod-ipad-watch.htm>iPhone / iPod / iPad / Watch</a>
+                  <li><a href=/forums/0-1000041-0-1-0-1-0-windows-phone.htm>Windows Phone</a>
                 </ul>
                 <ul>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-1000005-0-1-0-1-0-android.htm>Android</a>
+                  <li><a href=/forums/0-1000005-0-1-0-1-0-android.htm>Android</a>
                 </ul>
               </div>
             </div>
@@ -584,31 +582,31 @@ var oldHtmlCode =
             <div class=forum-section>
               <div class="fs-header microsoft"></div>
               <div class=fs-body>
-                <h3><a href=https://www.jeuxvideo.com/forums/0-3017784-0-1-0-1-0-xbox-scarlett.htm>Xbox Series X</a></h3>
-                <h3><a href=https://www.jeuxvideo.com/forums/0-1000044-0-1-0-1-0-xbox-one.htm>Xbox One</a></h3>
-                <h3><a href=https://www.jeuxvideo.com/forums/0-61-0-1-0-1-0-xbox-360.htm>Xbox 360</a></h3>
+                <h3><a href=/forums/0-3017784-0-1-0-1-0-xbox-scarlett.htm>Xbox Series X</a></h3>
+                <h3><a href=/forums/0-1000044-0-1-0-1-0-xbox-one.htm>Xbox One</a></h3>
+                <h3><a href=/forums/0-61-0-1-0-1-0-xbox-360.htm>Xbox 360</a></h3>
                 <ul>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-1000000-0-1-0-1-0-xbox-live-arcade.htm>Xbox Live Arcade</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-1000023-0-1-0-1-0-xbox-originals.htm>Xbox Originals</a>
+                  <li><a href=/forums/0-1000000-0-1-0-1-0-xbox-live-arcade.htm>Xbox Live Arcade</a>
+                  <li><a href=/forums/0-1000023-0-1-0-1-0-xbox-originals.htm>Xbox Originals</a>
                 </ul>
               </div>
             </div>
             <div class=forum-section>
               <div class="fs-header nintendo"></div>
               <div class=fs-body>
-                <h3><a href=https://www.jeuxvideo.com/forums/0-3007199-0-1-0-1-0-nintendo-switch.htm>Nintendo Switch</a></h3>
-                <h3><a href=https://www.jeuxvideo.com/forums/0-1000011-0-1-0-1-0-wii-u.htm>Wii U</a></h3>
-                <h3><a href=https://www.jeuxvideo.com/forums/0-62-0-1-0-1-0-wii.htm>Wii</a></h3>
+                <h3><a href=/forums/0-3007199-0-1-0-1-0-nintendo-switch.htm>Nintendo Switch</a></h3>
+                <h3><a href=/forums/0-1000011-0-1-0-1-0-wii-u.htm>Wii U</a></h3>
+                <h3><a href=/forums/0-62-0-1-0-1-0-wii.htm>Wii</a></h3>
                 <ul>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-1000024-0-1-0-1-0-wii-ware-console-virtuelle.htm>Wii Ware & Console virtuelle</a>
+                  <li><a href=/forums/0-1000024-0-1-0-1-0-wii-ware-console-virtuelle.htm>Wii Ware & Console virtuelle</a>
                 </ul>
-                <h3><a href=https://www.jeuxvideo.com/forums/0-1000039-0-1-0-1-0-nintendo-3ds.htm>3DS</a></h3>
+                <h3><a href=/forums/0-1000039-0-1-0-1-0-nintendo-3ds.htm>3DS</a></h3>
               </div>
             </div>
             <div class=forum-section>
               <div class="fs-header stadia"></div>
               <div class=fs-body>
-                <h3><a href=https://www.jeuxvideo.com/forums/0-3019067-0-1-0-1-0-stadia.htm>Google Stadia</a></h3>
+                <h3><a href=/forums/0-3019067-0-1-0-1-0-stadia.htm>Google Stadia</a></h3>
               </div>
             </div>
           </div>
@@ -621,22 +619,22 @@ var oldHtmlCode =
             <div class=forum-section>
               <div class="fs-header informatique"></div>
               <div class=fs-body>
-                <h3><a href=https://www.jeuxvideo.com/forums/0-1-0-1-0-1-0-informatique.htm>Informatique</a></h3>
+                <h3><a href=/forums/0-1-0-1-0-1-0-informatique.htm>Informatique</a></h3>
                 <ul>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-6-0-1-0-1-0-materiel-informatique.htm>Hardware</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-11-0-1-0-1-0-macintosh.htm>Mac</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-38-0-1-0-1-0-linux.htm>Linux</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-1000048-0-1-0-1-0-steam-os.htm>Steam Deck</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-28-0-1-0-1-0-tv-hifi-home-cinema.htm>TV - HiFi- Home Cinema</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-71-0-1-0-1-0-jeux.htm>Jeux</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-31-0-1-0-1-0-creation-de-jeux.htm>Création de jeux</a>
+                  <li><a href=/forums/0-6-0-1-0-1-0-materiel-informatique.htm>Hardware</a>
+                  <li><a href=/forums/0-11-0-1-0-1-0-macintosh.htm>Mac</a>
+                  <li><a href=/forums/0-38-0-1-0-1-0-linux.htm>Linux</a>
+                  <li><a href=/forums/0-1000048-0-1-0-1-0-steam-os.htm>Steam Deck</a>
+                  <li><a href=/forums/0-28-0-1-0-1-0-tv-hifi-home-cinema.htm>TV - HiFi- Home Cinema</a>
+                  <li><a href=/forums/0-71-0-1-0-1-0-jeux.htm>Jeux</a>
+                  <li><a href=/forums/0-31-0-1-0-1-0-creation-de-jeux.htm>Création de jeux</a>
                 </ul>
                 <ul>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-30-0-1-0-1-0-creation-de-sites-web.htm>Création de sites web</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-47-0-1-0-1-0-programmation.htm>Programmation</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-90-0-1-0-1-0-internet.htm>Internet</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-66-0-1-0-1-0-tuning-pc.htm>Modélisation 3D</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-1000030-0-1-0-1-0-montage-video.htm>Montage vidéo</a>
+                  <li><a href=/forums/0-30-0-1-0-1-0-creation-de-sites-web.htm>Création de sites web</a>
+                  <li><a href=/forums/0-47-0-1-0-1-0-programmation.htm>Programmation</a>
+                  <li><a href=/forums/0-90-0-1-0-1-0-internet.htm>Internet</a>
+                  <li><a href=/forums/0-66-0-1-0-1-0-tuning-pc.htm>Modélisation 3D</a>
+                  <li><a href=/forums/0-1000030-0-1-0-1-0-montage-video.htm>Montage vidéo</a>
                 </ul>
               </div>
             </div>
@@ -645,15 +643,15 @@ var oldHtmlCode =
             <div class=forum-section>
               <div class="fs-header art"></div>
               <div class=fs-body>
-                <h3><a href=https://www.jeuxvideo.com/forums/0-3000476-0-1-0-1-0-art.htm>Art</a></h3>
+                <h3><a href=/forums/0-3000476-0-1-0-1-0-art.htm>Art</a></h3>
                 <ul>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-26-0-1-0-1-0-cinema.htm>Cinéma</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-32-0-1-0-1-0-television-series.htm>Télévision & séries</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-98-0-1-0-1-0-animation.htm>Animation</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-25-0-1-0-1-0-musique.htm>Musique</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-34-0-1-0-1-0-livres.htm>Livres</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-27-0-1-0-1-0-bd-mangas-comics.htm>BD - Mangas - Comics</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-1000009-0-1-0-1-0-photographie.htm>Photographie</a>
+                  <li><a href=/forums/0-26-0-1-0-1-0-cinema.htm>Cinéma</a>
+                  <li><a href=/forums/0-32-0-1-0-1-0-television-series.htm>Télévision & séries</a>
+                  <li><a href=/forums/0-98-0-1-0-1-0-animation.htm>Animation</a>
+                  <li><a href=/forums/0-25-0-1-0-1-0-musique.htm>Musique</a>
+                  <li><a href=/forums/0-34-0-1-0-1-0-livres.htm>Livres</a>
+                  <li><a href=/forums/0-27-0-1-0-1-0-bd-mangas-comics.htm>BD - Mangas - Comics</a>
+                  <li><a href=/forums/0-1000009-0-1-0-1-0-photographie.htm>Photographie</a>
                 </ul>
               </div>
             </div>
@@ -667,51 +665,51 @@ var oldHtmlCode =
             <div class=forum-section>
               <div class="fs-header sport"></div>
               <div class=fs-body>
-                <h3><a href=https://www.jeuxvideo.com/forums/0-24-0-1-0-1-0-sport.htm>Sport</a></h3>
+                <h3><a href=/forums/0-24-0-1-0-1-0-sport.htm>Sport</a></h3>
                 <ul>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-20-0-1-0-1-0-football.htm>Football</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-79-0-1-0-1-0-catch.htm>Catch</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-78-0-1-0-1-0-musculation-nutrition.htm>Musculation & nutrition</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-33-0-1-0-1-0-tennis.htm>Tennis</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-29-0-1-0-1-0-basket.htm>Basket</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-21-0-1-0-1-0-rugby.htm>Rugby</a>
+                  <li><a href=/forums/0-20-0-1-0-1-0-football.htm>Football</a>
+                  <li><a href=/forums/0-79-0-1-0-1-0-catch.htm>Catch</a>
+                  <li><a href=/forums/0-78-0-1-0-1-0-musculation-nutrition.htm>Musculation & nutrition</a>
+                  <li><a href=/forums/0-33-0-1-0-1-0-tennis.htm>Tennis</a>
+                  <li><a href=/forums/0-29-0-1-0-1-0-basket.htm>Basket</a>
+                  <li><a href=/forums/0-21-0-1-0-1-0-rugby.htm>Rugby</a>
                 </ul>
                 <ul>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-88-0-1-0-1-0-boxe.htm>Boxe</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-46-0-1-0-1-0-cyclisme.htm>Cyclisme</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-23-0-1-0-1-0-sports-de-glisse.htm>Sports de glisse</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-22-0-1-0-1-0-sports-mecaniques.htm>Sports mécaniques</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-82-0-1-0-1-0-tennis-de-table.htm>Tennis de table</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-45-0-1-0-1-0-arts-martiaux-sports-de-combat.htm>Arts martiaux / Sports de combat</a>
+                  <li><a href=/forums/0-88-0-1-0-1-0-boxe.htm>Boxe</a>
+                  <li><a href=/forums/0-46-0-1-0-1-0-cyclisme.htm>Cyclisme</a>
+                  <li><a href=/forums/0-23-0-1-0-1-0-sports-de-glisse.htm>Sports de glisse</a>
+                  <li><a href=/forums/0-22-0-1-0-1-0-sports-mecaniques.htm>Sports mécaniques</a>
+                  <li><a href=/forums/0-82-0-1-0-1-0-tennis-de-table.htm>Tennis de table</a>
+                  <li><a href=/forums/0-45-0-1-0-1-0-arts-martiaux-sports-de-combat.htm>Arts martiaux / Sports de combat</a>
                 </ul>
               </div>
             </div>
             <div class=forum-section>
               <div class="fs-header culture"></div>
               <div class=fs-body>
-                <h3><a href=https://www.jeuxvideo.com/forums/0-3000481-0-1-0-1-0-savoir-culture.htm>Savoir & Culture</a></h3>
+                <h3><a href=/forums/0-3000481-0-1-0-1-0-savoir-culture.htm>Savoir & Culture</a></h3>
                 <ul>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-35-0-1-0-1-0-cours-et-devoirs.htm>Cours & devoirs</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-70-0-1-0-1-0-metiers-orientation.htm>Métiers & Orientation</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-59-0-1-0-1-0-histoire.htm>Histoire</a>
+                  <li><a href=/forums/0-35-0-1-0-1-0-cours-et-devoirs.htm>Cours & devoirs</a>
+                  <li><a href=/forums/0-70-0-1-0-1-0-metiers-orientation.htm>Métiers & Orientation</a>
+                  <li><a href=/forums/0-59-0-1-0-1-0-histoire.htm>Histoire</a>
                 </ul>
                 <ul>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-68-0-1-0-1-0-philosophie.htm>Philosophie</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-55-0-1-0-1-0-politique.htm>Politique</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-1000001-0-1-0-1-0-environnement.htm>Environnement & Nature</a>
+                  <li><a href=/forums/0-68-0-1-0-1-0-philosophie.htm>Philosophie</a>
+                  <li><a href=/forums/0-55-0-1-0-1-0-politique.htm>Politique</a>
+                  <li><a href=/forums/0-1000001-0-1-0-1-0-environnement.htm>Environnement & Nature</a>
                 </ul>
               </div>
             </div>
             <div class=forum-section>
               <div class="fs-header salons"></div>
               <div class=fs-body>
-                <h3><a href=https://www.jeuxvideo.com/forums/0-3011927-0-1-0-1-0-finance.htm>Finance</a></h3>
+                <h3><a href=/forums/0-3011927-0-1-0-1-0-finance.htm>Finance</a></h3>
               </div>
             </div>
             <div class=forum-section>
               <div class="fs-header actu"></div>
               <div class=fs-body>
-                <h3><a href=https://www.jeuxvideo.com/forums/0-69-0-1-0-1-0-actualites.htm>Actualités</a></h3>
+                <h3><a href=/forums/0-69-0-1-0-1-0-actualites.htm>Actualités</a></h3>
               </div>
             </div>
           </div>
@@ -719,44 +717,44 @@ var oldHtmlCode =
             <div class=forum-section>
               <div class="fs-header sciences"></div>
               <div class=fs-body>
-                <h3><a href=https://www.jeuxvideo.com/forums/0-65-0-1-0-1-0-sciences-technologies.htm>Sciences & Techno</a></h3>
+                <h3><a href=/forums/0-65-0-1-0-1-0-sciences-technologies.htm>Sciences & Techno</a></h3>
                 <ul>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-57-0-1-0-1-0-astronomie.htm>Astronomie</a>
+                  <li><a href=/forums/0-57-0-1-0-1-0-astronomie.htm>Astronomie</a>
                 </ul>
               </div>
             </div>
             <div class=forum-section>
               <div class="fs-header loisirs"></div>
               <div class=fs-body>
-                <h3><a href=https://www.jeuxvideo.com/forums/0-3000473-0-1-0-1-0-loisirs.htm>Loisirs</a></h3>
+                <h3><a href=/forums/0-3000473-0-1-0-1-0-loisirs.htm>Loisirs</a></h3>
                 <ul>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-1000019-0-1-0-1-0-automobiles.htm>Automobiles</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-67-0-1-0-1-0-cuisine.htm>Cuisine & Pâtisserie</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-39-0-1-0-1-0-nature-et-animaux.htm>Nature & Animaux</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-54-0-1-0-1-0-humour.htm>Humour</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-80-0-1-0-1-0-voyage.htm>Voyages</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-1000004-0-1-0-1-0-aviation.htm>Aviation</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-89-0-1-0-1-0-paranormal.htm>Paranormal</a>
+                  <li><a href=/forums/0-1000019-0-1-0-1-0-automobiles.htm>Automobiles</a>
+                  <li><a href=/forums/0-67-0-1-0-1-0-cuisine.htm>Cuisine & Pâtisserie</a>
+                  <li><a href=/forums/0-39-0-1-0-1-0-nature-et-animaux.htm>Nature & Animaux</a>
+                  <li><a href=/forums/0-54-0-1-0-1-0-humour.htm>Humour</a>
+                  <li><a href=/forums/0-80-0-1-0-1-0-voyage.htm>Voyages</a>
+                  <li><a href=/forums/0-1000004-0-1-0-1-0-aviation.htm>Aviation</a>
+                  <li><a href=/forums/0-89-0-1-0-1-0-paranormal.htm>Paranormal</a>
                 </ul>
               </div>
             </div>
             <div class=forum-section>
               <div class="fs-header creation"></div>
               <div class=fs-body>
-                <h3><a href=https://www.jeuxvideo.com/forums/0-3000405-0-1-0-1-0-creation.htm>Création</a></h3>
+                <h3><a href=/forums/0-3000405-0-1-0-1-0-creation.htm>Création</a></h3>
                 <ul>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-48-0-1-0-1-0-arts-graphiques.htm>Arts Graphiques</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-58-0-1-0-1-0-ecriture.htm>Écriture</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-1000031-0-1-0-1-0-modelisme.htm>Modélisme</a>
+                  <li><a href=/forums/0-48-0-1-0-1-0-arts-graphiques.htm>Arts Graphiques</a>
+                  <li><a href=/forums/0-58-0-1-0-1-0-ecriture.htm>Écriture</a>
+                  <li><a href=/forums/0-1000031-0-1-0-1-0-modelisme.htm>Modélisme</a>
                 </ul>
               </div>
             </div>
             <div class=forum-section>
               <div class="fs-header sante"></div>
               <div class=fs-body>
-                <h3><a href=https://www.jeuxvideo.com/forums/0-3002340-0-1-0-1-0-sante-et-bien-etre.htm>Santé & Bien-être</a></h3>
+                <h3><a href=/forums/0-3002340-0-1-0-1-0-sante-et-bien-etre.htm>Santé & Bien-être</a></h3>
                 <ul>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-3002014-0-1-0-1-0-sexualite.htm>Sexualité</a>
+                  <li><a href=/forums/0-3002014-0-1-0-1-0-sexualite.htm>Sexualité</a>
                 </ul>
               </div>
             </div>
@@ -770,17 +768,17 @@ var oldHtmlCode =
             <div class=forum-section>
               <div class="fs-body f-blabla">
                 <ul>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-15-0-1-0-1-0-blabla-moins-de-15-ans.htm>Moins de 15 ans</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-50-0-1-0-1-0-blabla-15-18-ans.htm>15 - 18 ans</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-51-0-1-0-1-0-blabla-18-25-ans.htm>18 - 25 ans</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-52-0-1-0-1-0-blabla-25-35-ans.htm>25 - 35 ans</a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-53-0-1-0-1-0-blabla-35-ans-et-plus.htm>Plus de 35 ans</a>
+                  <li><a href=/forums/0-15-0-1-0-1-0-blabla-moins-de-15-ans.htm>Moins de 15 ans</a>
+                  <li><a href=/forums/0-50-0-1-0-1-0-blabla-15-18-ans.htm>15 - 18 ans</a>
+                  <li><a href=/forums/0-51-0-1-0-1-0-blabla-18-25-ans.htm>18 - 25 ans</a>
+                  <li><a href=/forums/0-52-0-1-0-1-0-blabla-25-35-ans.htm>25 - 35 ans</a>
+                  <li><a href=/forums/0-53-0-1-0-1-0-blabla-35-ans-et-plus.htm>Plus de 35 ans</a>
                 </ul>
                 <ul>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-1000020-0-1-0-1-0-belgique.htm>Belgique <i class=be></i></a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-1000022-0-1-0-1-0-suisse.htm>Suisse <i class=ch></i></a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-83-0-1-0-1-0-quebec.htm>Québec <i class=ca></i></a>
-                  <li><a href=https://www.jeuxvideo.com/forums/0-1000034-0-1-0-1-0-japon.htm>Japon <i class=jp></i></a>
+                  <li><a href=/forums/0-1000020-0-1-0-1-0-belgique.htm>Belgique <i class=be></i></a>
+                  <li><a href=/forums/0-1000022-0-1-0-1-0-suisse.htm>Suisse <i class=ch></i></a>
+                  <li><a href=/forums/0-83-0-1-0-1-0-quebec.htm>Québec <i class=ca></i></a>
+                  <li><a href=/forums/0-1000034-0-1-0-1-0-japon.htm>Japon <i class=jp></i></a>
                 </ul>
               </div>
             </div>
@@ -800,21 +798,21 @@ var oldHtmlCode =
         <div class="card-forum-title card-header">Top Forums</div>
         <div class="card-body p-2">
           <ol class="fw-bold mb-0">
-            <li><a href=https://www.jeuxvideo.com/forums/0-3016891-0-1-0-1-0-genshin-impact.htm class="lh-sm card-forum-link">Genshin Impact</a>
-            <li><a href=https://www.jeuxvideo.com/forums/0-19163-0-1-0-1-0-league-of-legends.htm class="lh-sm card-forum-link">League of Legends</a>
-            <li><a href=https://www.jeuxvideo.com/forums/0-3020938-0-1-0-1-0-football-manager-2024.htm class="lh-sm card-forum-link">Football Manager 2024</a>
-            <li><a href=https://www.jeuxvideo.com/forums/0-3021932-0-1-0-1-0-topspin-2k25.htm class="lh-sm card-forum-link">TopSpin 2K25</a>
-            <li><a href=https://www.jeuxvideo.com/forums/0-3020471-0-1-0-1-0-honkai-star-rail.htm class="lh-sm card-forum-link">Honkai : Star Rail</a>
-            <li><a href=https://www.jeuxvideo.com/forums/0-3016443-0-1-0-1-0-project-eve.htm class="lh-sm card-forum-link">Project EVE</a>
-            <li><a href=https://www.jeuxvideo.com/forums/0-31913-0-1-0-1-0-fallout-4.htm class="lh-sm card-forum-link">Fallout 4</a>
-            <li><a href=https://www.jeuxvideo.com/forums/0-3018329-0-1-0-1-0-manor-lords.htm class="lh-sm card-forum-link">Manor Lords</a>
-            <li><a href=https://www.jeuxvideo.com/forums/0-3021379-0-1-0-1-0-tekken-8.htm class="lh-sm card-forum-link">Tekken 8</a>
-            <li><a href=https://www.jeuxvideo.com/forums/0-3021249-0-1-0-1-0-helldivers-ii.htm class="lh-sm card-forum-link">Helldivers II</a>
-            <li><a href=https://www.jeuxvideo.com/forums/0-3018929-0-1-0-1-0-total-war-warhammer-iii.htm class="lh-sm card-forum-link">Total War : Warhammer III</a>
-            <li><a href=https://www.jeuxvideo.com/forums/0-3004142-0-1-0-1-0-dragon-ball-z-dokkan-battle.htm class="lh-sm card-forum-link">Dragon Ball Z Dokkan Battle</a>
-            <li><a href=https://www.jeuxvideo.com/forums/0-3016975-0-1-0-1-0-elden-ring.htm class="lh-sm card-forum-link">Elden Ring</a>
-            <li><a href=https://www.jeuxvideo.com/forums/0-3018433-0-1-0-1-0-eiyuden-chronicle-hundred-heroes.htm class="lh-sm card-forum-link">Eiyuden Chronicle : Hundred Heroes</a>
-            <li><a href=https://www.jeuxvideo.com/forums/0-4526-0-1-0-1-0-baldur-s-gate-3.htm class="lh-sm card-forum-link">Baldur's Gate 3</a>
+            <li><a href=/forums/0-3016891-0-1-0-1-0-genshin-impact.htm class="lh-sm card-forum-link">Genshin Impact</a>
+            <li><a href=/forums/0-19163-0-1-0-1-0-league-of-legends.htm class="lh-sm card-forum-link">League of Legends</a>
+            <li><a href=/forums/0-3020938-0-1-0-1-0-football-manager-2024.htm class="lh-sm card-forum-link">Football Manager 2024</a>
+            <li><a href=/forums/0-3021932-0-1-0-1-0-topspin-2k25.htm class="lh-sm card-forum-link">TopSpin 2K25</a>
+            <li><a href=/forums/0-3020471-0-1-0-1-0-honkai-star-rail.htm class="lh-sm card-forum-link">Honkai : Star Rail</a>
+            <li><a href=/forums/0-3016443-0-1-0-1-0-project-eve.htm class="lh-sm card-forum-link">Project EVE</a>
+            <li><a href=/forums/0-31913-0-1-0-1-0-fallout-4.htm class="lh-sm card-forum-link">Fallout 4</a>
+            <li><a href=/forums/0-3018329-0-1-0-1-0-manor-lords.htm class="lh-sm card-forum-link">Manor Lords</a>
+            <li><a href=/forums/0-3021379-0-1-0-1-0-tekken-8.htm class="lh-sm card-forum-link">Tekken 8</a>
+            <li><a href=/forums/0-3021249-0-1-0-1-0-helldivers-ii.htm class="lh-sm card-forum-link">Helldivers II</a>
+            <li><a href=/forums/0-3018929-0-1-0-1-0-total-war-warhammer-iii.htm class="lh-sm card-forum-link">Total War : Warhammer III</a>
+            <li><a href=/forums/0-3004142-0-1-0-1-0-dragon-ball-z-dokkan-battle.htm class="lh-sm card-forum-link">Dragon Ball Z Dokkan Battle</a>
+            <li><a href=/forums/0-3016975-0-1-0-1-0-elden-ring.htm class="lh-sm card-forum-link">Elden Ring</a>
+            <li><a href=/forums/0-3018433-0-1-0-1-0-eiyuden-chronicle-hundred-heroes.htm class="lh-sm card-forum-link">Eiyuden Chronicle : Hundred Heroes</a>
+            <li><a href=/forums/0-4526-0-1-0-1-0-baldur-s-gate-3.htm class="lh-sm card-forum-link">Baldur's Gate 3</a>
           </ol>
         </div>
       </div>
@@ -831,22 +829,22 @@ var oldHtmlCode =
         </div>
         <div class=sideOrderedGames__body>
           <div class=sideOrderedGames__gameContainer style=order:0><span class=sideOrderedGames__gameRank style=opacity:1>1</span> <span class=sideOrderedGames__gameBlock>
-              <div class=sideOrderedGames__gameTitleContainer><a href=https://www.jeuxvideo.com/jeux/jeu-558354/ class="xXx sideOrderedGames__gameTitle">Grand Theft Auto VI</a></div><span class=sideOrderedGames__gameReleaseDate>2025</span>
+              <div class=sideOrderedGames__gameTitleContainer><a href=/jeux/jeu-558354/ class="xXx sideOrderedGames__gameTitle">Grand Theft Auto VI</a></div><span class=sideOrderedGames__gameReleaseDate>2025</span>
             </span></div>
           <div class=sideOrderedGames__gameContainer style=order:2><span class=sideOrderedGames__gameRank style=opacity:.9>2</span> <span class=sideOrderedGames__gameBlock>
-              <div class=sideOrderedGames__gameTitleContainer><a href=https://www.jeuxvideo.com/jeux/jeu-1349958/ class="xXx sideOrderedGames__gameTitle">Star Wars Outlaws</a></div><span class=sideOrderedGames__gameReleaseDate>30 août 2024</span>
+              <div class=sideOrderedGames__gameTitleContainer><a href=/jeux/jeu-1349958/ class="xXx sideOrderedGames__gameTitle">Star Wars Outlaws</a></div><span class=sideOrderedGames__gameReleaseDate>30 août 2024</span>
             </span></div>
           <div class=sideOrderedGames__gameContainer style=order:4><span class=sideOrderedGames__gameRank style=opacity:.8>3</span> <span class=sideOrderedGames__gameBlock>
-              <div class=sideOrderedGames__gameTitleContainer><a href=https://www.jeuxvideo.com/jeux/jeu-1161426/ class="xXx sideOrderedGames__gameTitle">Senua's Saga : Hellblade II</a></div><span class=sideOrderedGames__gameReleaseDate>21 mai 2024</span>
+              <div class=sideOrderedGames__gameTitleContainer><a href=/jeux/jeu-1161426/ class="xXx sideOrderedGames__gameTitle">Senua's Saga : Hellblade II</a></div><span class=sideOrderedGames__gameReleaseDate>21 mai 2024</span>
             </span></div>
           <div class=sideOrderedGames__gameContainer style=order:1><span class=sideOrderedGames__gameRank style=opacity:.7>4</span> <span class=sideOrderedGames__gameBlock>
-              <div class=sideOrderedGames__gameTitleContainer><a href=https://www.jeuxvideo.com/jeux/jeu-1521484/ class="xXx sideOrderedGames__gameTitle">Solo Leveling : Arise</a></div><span class=sideOrderedGames__gameReleaseDate>05 mai 2024</span>
+              <div class=sideOrderedGames__gameTitleContainer><a href=/jeux/jeu-1521484/ class="xXx sideOrderedGames__gameTitle">Solo Leveling : Arise</a></div><span class=sideOrderedGames__gameReleaseDate>05 mai 2024</span>
             </span></div>
           <div class=sideOrderedGames__gameContainer style=order:3><span class=sideOrderedGames__gameRank style=opacity:.6>5</span> <span class=sideOrderedGames__gameBlock>
-              <div class=sideOrderedGames__gameTitleContainer><a href=https://www.jeuxvideo.com/jeux/jeu-1876363/ class="xXx sideOrderedGames__gameTitle">Kingdom Come Deliverance 2</a></div><span class=sideOrderedGames__gameReleaseDate>2024</span>
+              <div class=sideOrderedGames__gameTitleContainer><a href=/jeux/jeu-1876363/ class="xXx sideOrderedGames__gameTitle">Kingdom Come Deliverance 2</a></div><span class=sideOrderedGames__gameReleaseDate>2024</span>
             </span></div>
         </div>
-        <div class=sideModule__footer><a href=https://www.jeuxvideo.com/jeux/attendus/ class="xXx sideModule__cta simpleButton">Tous les jeux attendus</a></div>
+        <div class=sideModule__footer><a href=/jeux/attendus/ class="xXx sideModule__cta simpleButton">Tous les jeux attendus</a></div>
       </div>
       <div class="sideDfp sideDfp--rectangle_btf">
         <div class=sideDfp__inner>


### PR DESCRIPTION
Exemple :
href="https://www.jeuxvideo.com/forums/0-51-0-1-0-1-0-blabla-18-25-ans.htm"
devient => 
href="/forums/0-51-0-1-0-1-0-blabla-18-25-ans.htm"

C'est comme ça dans le code html du site ça doit venir des vieux backup web archive, je switch tout en lien relatif pour reduite l'erreur.
et économise de la place 
+ lisibilité

**C'est traité par lot avec un soft donc très peu de risque d'erreur humaine sur ce changement**