### PR TITLE
(Mise en cache tu top forum) Retour en arrière (on a pas besoin que les liens pop direct

### DIFF
--- a/JVCForumRollback.meta.js
+++ b/JVCForumRollback.meta.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         JVCForumRollback
 // @namespace    https://github.com/Roadou
-// @version      6.0.7
+// @version      6.0.9
 // @description  Ancienne page des forums JVC
 // @author       IceFairy, Atlantis
 // @match        *://www.jeuxvideo.com/forums.htm

--- a/JVCForumRollback.user.js
+++ b/JVCForumRollback.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         JVCForumRollback
 // @namespace    https://github.com/Roadou
-// @version      6.0.7
+// @version      6.0.9
 // @description  Ancienne page des forums JVC
 // @author       IceFairy, Atlantis
 // @match        *://www.jeuxvideo.com/forums.htm
@@ -837,10 +837,8 @@ oldblocjeux.parentNode.replaceChild(blocjeuxnew, oldblocjeux);
 page.appendChild(footer);
 
 //cache_top_forum_eviter_fouc________
-//links = JSON.parse(localStorage.getItem("jvcrollback-links")) || [];
 //titles = JSON.parse(localStorage.getItem("jvcrollback-titles")) || [];
-
-let links = JSON.parse(localStorage.getItem("jvcrollback-links")) || [];
+let links = [];
 let titles = JSON.parse(localStorage.getItem("jvcrollback-titles")) || [];
 
 //Apres_coup____________________________
@@ -874,7 +872,6 @@ setTimeout(() => {
 
     collectLinksAndTitles();
 
-    localStorage.setItem("jvcrollback-links", JSON.stringify(links));
     localStorage.setItem("jvcrollback-titles", JSON.stringify(titles));
 
     updateLinks()


### PR DESCRIPTION
(Mise en cache tu top forum) Retour en arrière (on a pas besoin que les liens pop direct

Ouais comme j'ai dit j'avais fait un système de cache pour afficher directement les top forums sans faire toute une série de calculs pour aller les chercher sur la page actuelle dès le départ ça le fait après coup une 2nde après

Je viens de calculer que pour les liens c'était inutile que les liens POP instantanément.

Je suis en train d'anticiper un autre problème mais normalement ça devrait faire l'affaire
