### PR TITLE
(mise à jour icone => bug) l'image de jvflux qui servait à illustrer ne marche plus

### DIFF
--- a/JVCForumRollback.meta.js
+++ b/JVCForumRollback.meta.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         JVCForumRollback
 // @namespace    https://github.com/Roadou
-// @version      6.5.7
+// @version      6.5.8
 // @description  Ancienne page des forums JVC
 // @author       IceFairy, Atlantis
 // @match        *://www.jeuxvideo.com/forums.htm

--- a/JVCForumRollback.user.js
+++ b/JVCForumRollback.user.js
@@ -1,11 +1,11 @@
 // ==UserScript==
 // @name         JVCForumRollback
 // @namespace    https://github.com/Roadou
-// @version      6.5.7
+// @version      6.5.8
 // @description  Ancienne page des forums JVC
 // @author       IceFairy, Atlantis
 // @match        *://www.jeuxvideo.com/forums.htm
-// @icon         https://jvflux.fr/images/2/2e/forum_accueil_jeuxvideo.com_blabla.png
+// @icon         https://image.jeuxvideo.com/medias-xs/168862/1688618763-3707-capture-d-ecran.png
 // @grant        none
 // @run-at       document-end
 // @downloadURL  https://github.com/Roadou/JVCForumRollback/raw/main/JVCForumRollback.user.js

--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@
 
 #
 
-![Ancienne page forum](https://jvflux.fr/images/2/2e/forum_accueil_jeuxvideo.com_blabla.png)
+![Ancienne page forum](https://image.jeuxvideo.com/medias/168862/1688618763-3707-capture-d-ecran.png)


### PR DESCRIPTION
L'image de jvflux qui servait à illustrer ne marche plus  / marche mal

Donc changement d'icone

**Pas d'autre changement dans le code**