### PR TITLE
Pushh(mise à jour icone => bug v2) l'image de jvflux marche plus v2

### DIFF
--- a/JVCForumRollback.meta.js
+++ b/JVCForumRollback.meta.js
@@ -1,11 +1,11 @@
 // ==UserScript==
 // @name         JVCForumRollback
 // @namespace    https://github.com/Roadou
-// @version      6.5.8
+// @version      6.5.9
 // @description  Ancienne page des forums JVC
 // @author       IceFairy, Atlantis
 // @match        *://www.jeuxvideo.com/forums.htm
-// @icon         https://jvflux.fr/images/2/2e/forum_accueil_jeuxvideo.com_blabla.png
+// @icon         https://image.jeuxvideo.com/medias-xs/168862/1688618763-3707-capture-d-ecran.png
 // @grant        none
 // @run-at       document-end
 // @downloadURL  https://github.com/Roadou/JVCForumRollback/raw/main/JVCForumRollback.user.js

--- a/JVCForumRollback.user.js
+++ b/JVCForumRollback.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         JVCForumRollback
 // @namespace    https://github.com/Roadou
-// @version      6.5.8
+// @version      6.5.9
 // @description  Ancienne page des forums JVC
 // @author       IceFairy, Atlantis
 // @match        *://www.jeuxvideo.com/forums.htm


### PR DESCRIPTION
Pushh(mise à jour icone => bug v2) l'image de jvflux marche plus v2

J'avais modifié le script précédemment, mais je me suis rendu compte que j'ai oublié de modifier le fichier meta qui sert à vérifier la mise à jour sans charger le code en entier.

Je pourrais automatiser mais  flemmes

Bref mise à jour pour éviter les conflits de mise à jour et d'icône du script

**Sinon encore une fois aucun changement au niveau du code à part l'icône**
