### PR TITLE
(Retour icone JVC)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog JVCForumRollback
 
+## [6.6.9] (06/02/2025)
+
+- Retour sur l'ancienne icone du script (JVC) Allegement de cloudflare (normalement c'est bon)
+
 ## [6.6.8] (03/02/2025)
 
 - Repassage du forum switch 2 en postion 1 (car + frequenté et flemme de changer plus tard)

--- a/JVCForumRollback.meta.js
+++ b/JVCForumRollback.meta.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         JVCForumRollback
 // @namespace    https://github.com/Roadou
-// @version      6.6.8
+// @version      6.6.9
 // @description  Ancienne page des forums JVC
 // @author       IceFairy, Atlantis
 // @match        *://www.jeuxvideo.com/forums.htm

--- a/JVCForumRollback.user.js
+++ b/JVCForumRollback.user.js
@@ -1,11 +1,11 @@
 // ==UserScript==
 // @name         JVCForumRollback
 // @namespace    https://github.com/Roadou
-// @version      6.6.8
+// @version      6.6.9
 // @description  Ancienne page des forums JVC
 // @author       IceFairy, Atlantis
 // @match        *://www.jeuxvideo.com/forums.htm
-// @icon         https://raw.githubusercontent.com/Roadou/JVCForumRollback/refs/heads/main/resources/Old_Page_forum.png
+// @icon         https://image.jeuxvideo.com/medias-xs/168862/1688618763-3707-capture-d-ecran.png
 // @grant        none
 // @run-at       document-end
 // @downloadURL  https://github.com/Roadou/JVCForumRollback/raw/main/JVCForumRollback.user.js
@@ -13,7 +13,7 @@
 // @license      MIT
 // ==/UserScript==
 
-/* icon         https://image.jeuxvideo.com/medias-xs/168862/1688618763-3707-capture-d-ecran.png */
+/* icon         https://raw.githubusercontent.com/Roadou/JVCForumRollback/refs/heads/main/resources/Old_Page_forum.png */
 
 
 //1)Recuperer_Page_Actuelle_______

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Installer / Mettre à jour Script](https://img.shields.io/badge/Installer%20/%20Mettre%20%C3%A0%20jour%20le%20Script-Green?style=for-the-badge&color=1E971E)](https://github.com/Roadou/JVCForumRollback/raw/main/JVCForumRollback.user.js) ou sur [JVScript](https://jvscript.fr/script/jvcforumrollback)
 
-> [Changelog](https://github.com/Roadou/JVCForumRollback/blob/main/CHANGELOG.md#changelog-jvcforumrollback)
+> [Changelog](CHANGELOG.md#changelog-jvcforumrollback)
 
 #
 


### PR DESCRIPTION
Les images (JVC) semblent de nouveau accessibles, du coup au retour sur l'icône de JVC pour le script.
Et mise à jour de la description pour quelques chemins relatifs au lieu des chemins absolus.