### PR TITLE
Miniature Pokemon Z (exception)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog JVCForumRollback
 
+## [6.8.5] (28/02/2025)
+
+- Miniature Pokemon Z (exception)
+- Trouver une solution pour les prochaine jeux :hap: (encore en ToDo)
+
 ## [6.8.4] (19/02/2025)
 
 - Rajout de code en description en cas de retour en arrière (ne change rien sur l'execution)

--- a/JVCForumRollback.meta.js
+++ b/JVCForumRollback.meta.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         JVCForumRollback
 // @namespace    https://github.com/Roadou
-// @version      6.8.4
+// @version      6.8.5
 // @description  Ancienne page des forums JVC
 // @author       IceFairy, Atlantis
 // @match        *://www.jeuxvideo.com/forums.htm

--- a/JVCForumRollback.user.js
+++ b/JVCForumRollback.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         JVCForumRollback
 // @namespace    https://github.com/Roadou
-// @version      6.8.4
+// @version      6.8.5
 // @description  Ancienne page des forums JVC
 // @author       IceFairy, Atlantis
 // @match        *://www.jeuxvideo.com/forums.htm
@@ -29,6 +29,8 @@ let jaquettetopjeuimg = jaquettetopjeuimgbase.replace('medias-xs', 'medias-md');
 jaquettetopjeuimg = (jaquettetopjeuimg === 'https://image.jeuxvideo.com/medias-md/171466/1714656797-9405-jaquette-avant.png') ? 'https://cdn2.unrealengine.com/football-manager-2024-s-miles-jacobson-talks-past-present-and-future-of-the-football-sim-1920x1080-ec8779b5d071.jpeg' : jaquettetopjeuimg;
 //Kingdom_Come_Deliverance 2
 jaquettetopjeuimg = (jaquettetopjeuimg === 'https://image.jeuxvideo.com/medias-md/171346/1713464229-1879-jaquette-avant.jpg') ? 'https://image.jeuxvideo.com/medias-md/172426/1724264786-8139-capture-d-ecran.jpg' : jaquettetopjeuimg;
+//Pokemon_Z
+jaquettetopjeuimg = (jaquettetopjeuimg === 'https://image.jeuxvideo.com/medias-md/171026/1710255054-326-jaquette-avant.jpg') ? 'https://image.jeuxvideo.com/medias-md/173644/1736441929-5733-capture-d-ecran.jpg' : jaquettetopjeuimg;
 
 //recuperer_le_bloc_de_fin
 const footer = page.querySelector(".layout__row.layout__footer");


### PR DESCRIPTION
Miniature Pokemon Z (exception)

obligé pour l'instant d'avoir des exceptions pour certains jeux ...

faut que je trouve une solution à long terme en attendant :

```
//execeptions_fiches_jeux(va_chercher_une_autre_image_sinon_cest_moche)____
//football
jaquettetopjeuimg = (jaquettetopjeuimg === 'https://image.jeuxvideo.com/medias-md/171466/1714656797-9405-jaquette-avant.png') ? 'https://cdn2.unrealengine.com/football-manager-2024-s-miles-jacobson-talks-past-present-and-future-of-the-football-sim-1920x1080-ec8779b5d071.jpeg' : jaquettetopjeuimg;
//Kingdom_Come_Deliverance 2
jaquettetopjeuimg = (jaquettetopjeuimg === 'https://image.jeuxvideo.com/medias-md/171346/1713464229-1879-jaquette-avant.jpg') ? 'https://image.jeuxvideo.com/medias-md/172426/1724264786-8139-capture-d-ecran.jpg' : jaquettetopjeuimg;
//Pokemon_Z
jaquettetopjeuimg = (jaquettetopjeuimg === 'https://image.jeuxvideo.com/medias-md/171026/1710255054-326-jaquette-avant.jpg') ? 'https://image.jeuxvideo.com/medias-md/173644/1736441929-5733-capture-d-ecran.jpg' : jaquettetopjeuimg;
```

ç'est pour eviter de charger une minature par top niveau ratio en attendant une bonne idée .
