### PR TITLE
(miniature) top jeu mario  world switch 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,26 @@
 # Changelog JVCForumRollback
 
+## [6.8.9] (07/04/2025)
+
+- Retrait Miniature "AC Shadowns" (fin exception car mauvais ratio)
+- Ajout Miniature Mario Kart (exception car mauvais ratio)
+
 ## [6.8.8] (24/03/2025)
 
-- Miniature "AC Shadowns" (exception)
+- Miniature "AC Shadowns" (exception car mauvais ratio)
 
 ## [6.8.7] (12/03/2025)
 
-- Miniature "GTA VI" v2 (exception)
+- Miniature "GTA VI" v2 (exception car mauvais ratio)
 
 ## [6.8.6] (12/03/2025)
 
-- Miniature "GTA VI" (exception)
-- Retrait minature (exception) "Kingdom Come Deliverance 2"
+- Miniature "GTA VI" (exception car mauvais ratio)
+- Retrait minature (exception car mauvais ratio) "Kingdom Come Deliverance 2"
 
 ## [6.8.5] (28/02/2025)
 
-- Miniature Pokemon Z (exception)
+- Miniature Pokemon Z (exception car mauvais ratio)
 - Trouver une solution pour les prochaine jeux :hap: (encore en ToDo)
 
 ## [6.8.4] (19/02/2025)

--- a/JVCForumRollback.meta.js
+++ b/JVCForumRollback.meta.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         JVCForumRollback
 // @namespace    https://github.com/Roadou
-// @version      6.8.8
+// @version      6.8.9
 // @description  Ancienne page des forums JVC
 // @author       IceFairy, Atlantis
 // @match        *://www.jeuxvideo.com/forums.htm

--- a/JVCForumRollback.user.js
+++ b/JVCForumRollback.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         JVCForumRollback
 // @namespace    https://github.com/Roadou
-// @version      6.8.8
+// @version      6.8.9
 // @description  Ancienne page des forums JVC
 // @author       IceFairy, Atlantis
 // @match        *://www.jeuxvideo.com/forums.htm
@@ -25,14 +25,14 @@ const jaquettetopjeuimgbase = jaquettetopjeu.getAttribute('data-src') || jaquett
 let jaquettetopjeuimg = jaquettetopjeuimgbase.replace('medias-xs', 'medias-md');
 
 //execeptions_fiches_jeux(va_chercher_une_autre_image_sinon_cest_moche)____
-//football
+//football_manager
 jaquettetopjeuimg = (jaquettetopjeuimg === 'https://image.jeuxvideo.com/medias-md/171466/1714656797-9405-jaquette-avant.png') ? 'https://cdn2.unrealengine.com/football-manager-2024-s-miles-jacobson-talks-past-present-and-future-of-the-football-sim-1920x1080-ec8779b5d071.jpeg' : jaquettetopjeuimg;
 //Pokemon_Z
 jaquettetopjeuimg = (jaquettetopjeuimg === 'https://image.jeuxvideo.com/medias-md/171026/1710255054-326-jaquette-avant.jpg') ? 'https://image.jeuxvideo.com/medias-md/173644/1736441929-5733-capture-d-ecran.jpg' : jaquettetopjeuimg;
 //GTA_VI
 jaquettetopjeuimg = (jaquettetopjeuimg === 'https://image.jeuxvideo.com/medias-md/170230/1702303334-1969-jaquette-avant.jpeg') ? 'https://image.jeuxvideo.com/medias-md/172786/1727863534-4176-capture-d-ecran.jpg' : jaquettetopjeuimg;
-//AC_Shadow
-jaquettetopjeuimg = (jaquettetopjeuimg === 'https://image.jeuxvideo.com/medias-md/171579/1715789028-8027-jaquette-avant.png') ? 'https://image.jeuxvideo.com/medias-md/172356/1723559357-7019-capture-d-ecran.jpg' : jaquettetopjeuimg;
+//Mario_Arnaque90euro_world
+jaquettetopjeuimg = (jaquettetopjeuimg === 'https://image.jeuxvideo.com/medias-md/174360/1743599301-2480-jaquette-avant.jpg') ? 'https://image.jeuxvideo.com/medias-md/174367/1743673909-2831-capture-d-ecran.jpg' : jaquettetopjeuimg;
 
 
 //recuperer_le_bloc_de_fin


### PR DESCRIPTION
(miniature) top jeu Mario world switch 2

Toujours ce souci pour le top jeu de miniatures pas conforme à mettre à jour manuellement.

Je fais totalement du code webedia, mais je n'ai pas d'idée et une solution meilleure demanderait + de temps. 