### PR TITLE
(Préparation d'un nouveau système) Forums favoris

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog JVCForumRollback
 
+## [6.9.5] (29/04/2025)
+
+- Préparation d'un système de favoris à la place de l'image top jeu. (Non Actif)
+
 ## [6.9.1] (23/04/2025)
 
 - Clair Obscur (exception car mauvais ratio)

--- a/JVCForumRollback.meta.js
+++ b/JVCForumRollback.meta.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         JVCForumRollback
 // @namespace    https://github.com/Roadou
-// @version      6.9.1
+// @version      6.9.5
 // @description  Ancienne page des forums JVC
 // @author       IceFairy, Atlantis
 // @match        *://www.jeuxvideo.com/forums.htm

--- a/JVCForumRollback.user.js
+++ b/JVCForumRollback.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         JVCForumRollback
 // @namespace    https://github.com/Roadou
-// @version      6.9.1
+// @version      6.9.5
 // @description  Ancienne page des forums JVC
 // @author       IceFairy, Atlantis
 // @match        *://www.jeuxvideo.com/forums.htm
@@ -410,8 +410,10 @@ var oldHtmlCode =
               <div class="f-alaune">
                   <a href="#">
                     <img src=${jaquettetopjeuimg}>
+                    <!-- <img src="https://image.jeuxvideo.com/medias-md/157322/1573218277-2396-card.png" style="height: 100%; object-fit: cover; filter: grayscale(25%) brightness(107%);">  -->
                     <!-- <img src="https://static.jvc.gg/unversioned/img/default-og.png" style="height: 100%; object-fit: cover; filter: grayscale(25%) brightness(107%);">  -->
                   <p class="nom-forum">${titles[0]}</p>
+                  <!-- <p class="nom-forum">Forums Favoris</p>  -->
                 </a></div>
             </div>
           </div>
@@ -897,6 +899,8 @@ setTimeout(() => {
 
     updateLinks()
 
+    //updateFavProfil()
+
 }, 0);
 
 //8)Fonctions_d_usage______________
@@ -930,7 +934,7 @@ function collectLinksAndTitles() {
 
 
 
-//Update_top_jeu_page_remplacée
+//Update_top_jeu_page_remplacee_(Court_Therme)
 function updateLinks() {
     const meilleurjeutitre = document.querySelector('.col-lg-6 .nom-forum');
     const lienElement = document.querySelector('.col-lg-6 .f-alaune a');
@@ -941,4 +945,16 @@ function updateLinks() {
         element.href = links[index];
         element.textContent = titles[index];
     });
+}
+
+
+//Mise_en_Place_Favoris_Perso_(Futur)
+function updateFavProfil() {
+    let spanpseudo = document.querySelector('.headerAccount__pseudo');
+    let pseudoco = spanpseudo.textContent.toLowerCase();
+    const meilleurjeutitre = document.querySelector('.col-lg-6 .nom-forum');
+    const lienElement = document.querySelector('.col-lg-6 .f-alaune a');
+    if (pseudoco !== "connexion") {
+        lienElement.setAttribute('href', "/profil/" + pseudoco + "?mode=favoris");
+    }
 }


### PR DESCRIPTION
Préparation d'un nouveau système qui redirigera vers les forums favoris pour l'image d'en tête.

C'est en commentaire, rien n'est actif. Mais c'est une préparation pour pouvoir switcher si jamais un jour je dois abandonner la maintenance active des fiches de jeu **qui malheureusement n'a pas d'automatisme parfait.**

Ça ne change rien par rapport à la version précédente mais ça prépare le futur avec un système qui ramène vers les favoris du profil.