### PR TITLE
(miniature) top jeu mario world switch 2 v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog JVCForumRollback
 
+## [6.9.7] (08/06/2025)
+
+- Retrait Miniature Oblivion (fin exception car mauvais ratio)
+- Ajout Miniature Mario Kart (exception car mauvais ratio)
+
 ## [6.9.6] (29/04/2025)
 
 - Finalisation du système de favoris en vue de remplacer l'image top jeu. **(Non Actif / Commentaire)**

--- a/JVCForumRollback.meta.js
+++ b/JVCForumRollback.meta.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         JVCForumRollback
 // @namespace    https://github.com/Roadou
-// @version      6.9.6
+// @version      6.9.7
 // @description  Ancienne page des forums JVC
 // @author       IceFairy, Atlantis
 // @match        *://www.jeuxvideo.com/forums.htm

--- a/JVCForumRollback.user.js
+++ b/JVCForumRollback.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         JVCForumRollback
 // @namespace    https://github.com/Roadou
-// @version      6.9.6
+// @version      6.9.7
 // @description  Ancienne page des forums JVC
 // @author       IceFairy, Atlantis
 // @match        *://www.jeuxvideo.com/forums.htm
@@ -34,9 +34,7 @@ jaquettetopjeuimg = (jaquettetopjeuimg === 'https://image.jeuxvideo.com/medias-m
 //GTA_VI
 jaquettetopjeuimg = (jaquettetopjeuimg === 'https://image.jeuxvideo.com/medias-md/170230/1702303334-1969-jaquette-avant.jpeg') ? 'https://image.jeuxvideo.com/medias-md/172786/1727863534-4176-capture-d-ecran.jpg' : jaquettetopjeuimg;
 //Mario_drop_world
-//jaquettetopjeuimg = (jaquettetopjeuimg === 'https://image.jeuxvideo.com/medias-md/174360/1743599301-2480-jaquette-avant.jpg') ? 'https://image.jeuxvideo.com/medias-md/174367/1743673909-2831-capture-d-ecran.jpg' : jaquettetopjeuimg;
-//oblivion
-jaquettetopjeuimg = (jaquettetopjeuimg === 'https://image.jeuxvideo.com/images-md/pc/e/s/es4opc0f.jpg') ? 'https://image.jeuxvideo.com/medias-md/174534/1745338268-388-capture-d-ecran.jpg' : jaquettetopjeuimg;
+jaquettetopjeuimg = (jaquettetopjeuimg === 'https://image.jeuxvideo.com/medias-md/174773/1747733351-6826-jaquette-avant.jpg') ? 'https://image.jeuxvideo.com/medias-md/174367/1743673909-2831-capture-d-ecran.jpg' : jaquettetopjeuimg;
 //clair_obscure
 jaquettetopjeuimg = (jaquettetopjeuimg === 'https://image.jeuxvideo.com/medias-md/171803/1718033257-8476-jaquette-avant.jpg') ? 'https://image.jeuxvideo.com/medias-md/172909/1729090304-5615-capture-d-ecran.jpg' : jaquettetopjeuimg;
 //*/


### PR DESCRIPTION
(miniature) top jeu mario world switch 2 v2

J'avais mis en place pour éviter les mises à jour manuelles mais pour l'instant on reste comme ça quand on le ration ne correspond pas j'ajoute une exception manuellement, flemme de faire autrement.

👀